### PR TITLE
Fix U2 background subtype-clobber (prod hotfix → v2.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to intronIC will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.4] - 2026-06-01
+
+### Fixed — species U2 background subtype-clobber
+
+The species-specific U2 background correction silently reverted to the human U2
+prior on annotations containing non-canonical splice dinucleotides. The build
+mapped all non-canonical dnts to the `gtag` subtype and assigned the corrected
+matrix with sorted-dnt last-writer-wins, so a few spurious introns (e.g. `TT`,
+which sorts after `GT`) won the slot with a near-zero blend weight, overwriting
+the real high-n background. Harmless on near-human-composition species, but it
+inflated scores on compositionally-divergent (e.g. AT-rich) genomes, producing
+high-confidence false positives. Fixed by letting the highest-n dnt define each
+subtype background (order-independent, so streaming/in-memory results stay
+deterministic). Added a regression test.
+
 ## [2.4.3] - 2026-05-29
 
 ### Fixed — `-i` (`--allow-multiple-isoforms`) and `-d` (`--include-duplicates`) flag parity

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "intronic-refactored"
-version = "2.4.3"
+version = "2.4.4"
 description = "Intron classification tool for identifying U2-type and U12-type introns using SVM (refactored version)"
 authors = ["Graham E. Larue <egrahamlarue@gmail.com>"]
 channels = ["conda-forge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "intronIC"
-version = "2.4.3"
+version = "2.4.4"
 description = "Intron classification tool for identifying U2-type and U12-type introns using SVM"
 readme = "README.md"
 license = {text = "GPL-3.0"}

--- a/src/intronIC/scoring/background.py
+++ b/src/intronIC/scoring/background.py
@@ -464,20 +464,27 @@ class SpeciesBackground:
             if human_ps is None:
                 continue
 
-            # Iterate subtypes in sorted order so that when multiple
-            # subtypes map to the same pwm_subtype (e.g., non-canonical 5'
-            # dnts all default to 'gtag'), the last-writer-wins assignment
-            # to ``matrices[human_key]`` is deterministic. Without this,
-            # streaming and in-memory pipelines can produce different
-            # corrected PWMs for the same data because the underlying
-            # ``_data`` dict's insertion order differs (sequential
-            # accumulate vs parallel merge_worker_counts).
-            for subtype_dnt in sorted(acc.get_all_subtypes()):
+            # Multiple intron dnts map to the same pwm_subtype (all non-canonical
+            # 5' dnts default to 'gtag'). The HIGHEST-n dnt must define the slot.
+            # The previous code iterated sorted(dnts) and did last-writer-wins,
+            # which let a rare low-n non-canonical dnt (e.g. TT n=3) clobber the
+            # real GT background (n~96k) with a ~human matrix (w=n/(n+n0)~=0),
+            # silently disabling the species correction on any annotation that
+            # carries non-canonical dnts. Sort by (-n, dnt) [order-independent =>
+            # streaming/in-memory deterministic, the original goal] + first-writer-wins.
+            _u2_seen = set()
+            for subtype_dnt in sorted(
+                acc.get_all_subtypes(),
+                key=lambda d: (-acc._data.get(d, {}).get('n', 0), d),
+            ):
                 pwm_subtype = self.FIVE_DNT_TO_SUBTYPE.get(
                     subtype_dnt,
                     self.THREE_DNT_TO_SUBTYPE.get(subtype_dnt, 'gtag')
                 )
                 human_key = ('u2', pwm_subtype)
+                if human_key in _u2_seen:
+                    continue  # a higher-n dnt already defined this background
+                _u2_seen.add(human_key)
                 human_pwm = human_ps.matrices.get(human_key)
                 if human_pwm is None:
                     # Try fallback
@@ -558,9 +565,16 @@ class SpeciesBackground:
 
         human_bp = self.human_u2.get('bp')
         if human_bp:
-            for subtype_dnt in sorted(self._bp_acc.get_all_subtypes()):
+            _bp_u2_seen = set()
+            for subtype_dnt in sorted(
+                self._bp_acc.get_all_subtypes(),
+                key=lambda d: (-self._bp_acc._data.get(d, {}).get('n', 0), d),
+            ):
                 pwm_subtype = self.FIVE_DNT_TO_SUBTYPE.get(subtype_dnt, 'gtag')
                 human_key = ('u2', pwm_subtype)
+                if human_key in _bp_u2_seen:
+                    continue  # highest-n dnt wins (see 5'/3' loop; clobber-bug fix)
+                _bp_u2_seen.add(human_key)
                 human_pwm = human_bp.matrices.get(human_key)
                 if human_pwm is None:
                     human_pwm = human_bp.select_best('u2', pwm_subtype)

--- a/tests/unit/test_scoring/test_background.py
+++ b/tests/unit/test_scoring/test_background.py
@@ -209,3 +209,35 @@ class TestSpeciesBackground:
         a_freq = u2_five.matrix[0, 17]
         g_freq = u2_five.matrix[2, 17]
         assert a_freq > g_freq
+
+    def test_low_n_noncanonical_dnt_does_not_clobber(
+        self, human_u2_pwm_sets, default_config
+    ):
+        """Regression (U2 subtype-clobber bug): a rare non-canonical 5' dnt that
+        defaults to 'gtag' (e.g. TT) must NOT overwrite the high-n GT-derived gtag
+        background. The previous code sorted dnts and did last-writer-wins, so a
+        handful of TT introns (n=3, blend weight ~0 => ~human prior) clobbered the
+        GT background (n=2000), silently disabling the species correction on any
+        annotation carrying non-canonical dnts. Fix: highest-n dnt defines the slot."""
+        bg = SpeciesBackground(
+            human_u2_pwm_sets, default_config,
+            five_len=12, three_len=10, bp_len=12,
+        )
+        # 2000 canonical GT-AG introns, 5' window all-A => strongly species-shifted
+        # away from the uniform (0.25) human prior.
+        for i in range(2000):
+            bg.accumulate(f'gt_{i}', 'GT', 'AG', 'A' * 12, 'C' * 10, 'A' * 50)
+        # 3 non-canonical TT introns (5' dnt 'TT' -> defaults to 'gtag'), 5' all-G.
+        # 'TT' > 'GT' alphabetically, so last-writer-wins would let these win.
+        for i in range(3):
+            bg.accumulate(f'tt_{i}', 'TT', 'AG', 'G' * 12, 'C' * 10, 'A' * 50)
+
+        five = bg.build_corrected_pwm_sets()['five'].matrices[('u2', 'gtag')].matrix
+        # Scored window is cols 17-28, A is row 0. Under the fix the gtag background
+        # reflects the 2000 GT introns (A ~0.75); under the clobber bug it reverts
+        # to ~human uniform (~0.25).
+        a_scored = float(five[0, 17:29].mean())
+        assert a_scored > 0.5, (
+            f"gtag 5' A-freq={a_scored:.3f} in scored window: expected species-shifted "
+            f"(~0.75 from 2000 GT introns); ~0.25 means 3 TT introns clobbered it to human"
+        )


### PR DESCRIPTION
## Summary (prod hotfix → v2.4.4; bug is present in PyPI v2.4.3)
Fixes a silent bug in the species U2 background correction that disables the
correction on annotations carrying non-canonical splice dinucleotides, inflating
scores on compositionally-divergent species and producing high-confidence U12
false positives.

## Root cause
`SpeciesBackground._build_final_pwm_sets` maps all non-canonical splice dnts to
`'gtag'` (via the `FIVE/THREE_DNT_TO_SUBTYPE` defaults) and assigned the corrected
matrix into `matrices[('u2', pwm_subtype)]` in **sorted-dnt order with
last-writer-wins** (added in c406498 for streaming/in-memory determinism). Because
T-starting 5′ dnts and most non-AG 3′ dnts sort *after* the canonical `GT`/`AG`, a
handful of spurious non-canonical introns (e.g. 3× `TT`) win the `gtag` slot. Their
blend weight `w = n/(n+n0)` is ~0 at low n, so the corrected background collapses to
the **human U2 prior** — silently reverting the species correction.

## Impact
Conditional: harmless on near-human-composition species (revert-to-human is a no-op
— which is why gold validation passed and this went unnoticed), but it inflates raw
scores on compositionally-divergent species (AT-rich protists, etc.). Observed: a
confirmed U12-loss ciliate went **1 → 95** HC U12 on an annotation that happened to
carry a few non-canonical introns.

## Fix
Iterate subtypes by `(-n, dnt)` and first-writer-wins, so the **highest-n (canonical)
dnt defines each `pwm_subtype`** and rare low-n non-canonical dnts cannot clobber it.
The sort is order-independent, **preserving** the streaming/in-memory determinism
c406498 sought. Applied to the 5′/3′ and BPS loops.

## Verification
- New regression test (`test_low_n_noncanonical_dnt_does_not_clobber`): **fails
  pre-fix** (background reverts to the human prior), **passes post-fix**.
- Full unit suite green (657 passed).
- End-to-end: the loss ciliate goes **95 → 3** HC; a clean-annotation run of the same
  species is **unchanged (1 → 1)**; the dumped `gtag` background goes
  0.0006 → 0.136 (≈ the correctly-corrected value).

## Validation
- **Regression test** (`test_low_n_noncanonical_dnt_does_not_clobber`): fails pre-fix (background reverts to the human prior), passes post-fix.
- **Unit suite**: green (657 passed on main-line; 12 on v2.4.x).
- **Gold recall preserved** (buggy→fixed HC): *A. thaliana* 291→288, *D. melanogaster* 20→19, *Chlamydomonas* (loss) 3→3 — negligible; the fix does not disturb validated species.
- **Divergent bearers preserved**: gut fungi (Neocallimastix/Piromyces/Anaeromyces) and *Basidiobolus* HC change ≤10 — real U12 calls retained; core_fraction stays high (e.g. 0.97→0.77) so they remain trusted.
- ⚠️ One integration test (`test_modesep_pipeline.py::test_continuous_discount_preserves_strong_TPs`) fails — but it is **pre-existing on `main`** (fails on unfixed `main` too) and is **unrelated** to this change. (Not present on the v2.4.x line.)